### PR TITLE
feat(backend): agregar arquitectura de enrutamiento de agentes

### DIFF
--- a/plataforma-agricola-backend/app/agents/agent_nodes.py
+++ b/plataforma-agricola-backend/app/agents/agent_nodes.py
@@ -10,7 +10,7 @@ tools = [get_parcel_details, list_user_parcels]
 
 llm = ChatGoogleGenerativeAI(model="gemini-2.0-flash-exp", temperature=0, google_api_key=GOOGLE_API_KEY)
 
-def monitoring_agent_node(state: GraphState) -> dict:
+def general_tool_agent_node(state: GraphState) -> dict:
     """
     Nodo del Agente de Monitoreo, ahora potenciado con herramientas.
     
@@ -69,6 +69,48 @@ def sustainability_agent_node(state: GraphState) -> dict:
     - Si la recomendación es sostenible, apruébala y explica brevemente por qué.
     - Si NO es sostenible (ej. sugiere un pesticida químico fuerte), recházala y propón una alternativa orgánica o de bajo impacto.
     - Tu respuesta final será la que vea el agricultor.
+    """
+    
+    response = llm.invoke(prompt)
+    
+    return {"agent_response": response.content}
+
+def production_agent_node(state: GraphState) -> dict:
+    """Nodo del Agente de Optimización de la Producción."""
+    
+    prompt = f"""
+    Eres un agrónomo experto en optimización de la producción.
+    Basado en la siguiente pregunta del usuario y el historial de chat, proporciona una recomendación detallada para maximizar el rendimiento de los cultivos.
+    Pregunta: {state['user_query']}
+    Historial: {state['chat_history']}
+    """
+    
+    response = llm.invoke(prompt)
+    
+    return {"agent_response": response.content}
+
+def water_agent_node(state: GraphState) -> dict:
+    """Nodo del Agente de Gestión de Recursos Hídricos."""
+
+    prompt = f"""
+    Eres un hidrólogo experto en gestión del agua para la agricultura.
+    Basado en la siguiente pregunta del usuario y el historial de chat, proporciona una recomendación detallada sobre riego, conservación y calidad del agua.
+    Pregunta: {state['user_query']}
+    Historial: {state['chat_history']}
+    """
+    
+    response = llm.invoke(prompt)
+    
+    return {"agent_response": response.content}
+
+def supply_chain_agent_node(state: GraphState) -> dict:
+    """Nodo del Agente de Optimización de la Cadena de Suministro."""
+
+    prompt = f"""
+    Eres un experto en logística y cadena de suministro agrícola.
+    Basado en la siguiente pregunta del usuario y el historial de chat, proporciona una recomendación detallada sobre inventario, transporte y comercialización.
+    Pregunta: {state['user_query']}
+    Historial: {state['chat_history']}
     """
     
     response = llm.invoke(prompt)

--- a/plataforma-agricola-backend/app/agents/agent_nodes.py
+++ b/plataforma-agricola-backend/app/agents/agent_nodes.py
@@ -20,6 +20,7 @@ def general_tool_agent_node(state: GraphState) -> dict:
     Returns:
         Un diccionario con las actualizaciones para el estado.
     """
+    print("-- Node ejecutandose: General --")
     user_query = state["user_query"]
     user_id = state["user_id"]
     
@@ -51,12 +52,13 @@ def general_tool_agent_node(state: GraphState) -> dict:
         "chat_history": state["chat_history"]
     })
     
-    return {"recommendation_draft": response["output"]}
+    return {"recommendation_draft": response["output"], "agent_response": response["output"]}
 
 def sustainability_agent_node(state: GraphState) -> dict:
     """
     Nodo del Agente de Sostenibilidad. Revisa las recomendaciones.
     """
+    print("-- Node ejecutandose: sustainability --")
     recommendation_draft = state["recommendation_draft"]
     
     prompt = f"""
@@ -77,7 +79,7 @@ def sustainability_agent_node(state: GraphState) -> dict:
 
 def production_agent_node(state: GraphState) -> dict:
     """Nodo del Agente de Optimización de la Producción."""
-    
+    print("-- Node ejecutandose: Production --")
     prompt = f"""
     Eres un agrónomo experto en optimización de la producción.
     Basado en la siguiente pregunta del usuario y el historial de chat, proporciona una recomendación detallada para maximizar el rendimiento de los cultivos.
@@ -91,7 +93,7 @@ def production_agent_node(state: GraphState) -> dict:
 
 def water_agent_node(state: GraphState) -> dict:
     """Nodo del Agente de Gestión de Recursos Hídricos."""
-
+    print("-- Node ejecutandose: Water --")
     prompt = f"""
     Eres un hidrólogo experto en gestión del agua para la agricultura.
     Basado en la siguiente pregunta del usuario y el historial de chat, proporciona una recomendación detallada sobre riego, conservación y calidad del agua.
@@ -105,7 +107,7 @@ def water_agent_node(state: GraphState) -> dict:
 
 def supply_chain_agent_node(state: GraphState) -> dict:
     """Nodo del Agente de Optimización de la Cadena de Suministro."""
-
+    print("-- Node ejecutandose: Supply --")
     prompt = f"""
     Eres un experto en logística y cadena de suministro agrícola.
     Basado en la siguiente pregunta del usuario y el historial de chat, proporciona una recomendación detallada sobre inventario, transporte y comercialización.

--- a/plataforma-agricola-backend/app/agents/agent_router.py
+++ b/plataforma-agricola-backend/app/agents/agent_router.py
@@ -1,11 +1,9 @@
 from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_core.prompts import PromptTemplate
-from langchain_core.pydantic_v1 import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 from app.core.config import GOOGLE_API_KEY
 from app.agents.graph_state import GraphState
-
-llm = ChatGoogleGenerativeAI(model="gemini-2.0-flash-exp", temperature=0, google_api_key=GOOGLE_API_KEY)
 
 class RouteQuery(BaseModel):
     """Enruta una consulta de usuario a un agente especialista."""
@@ -34,7 +32,7 @@ def get_router():
         input_variables=["query"],
     )
 
-    llm = ChatGoogleGenerativeAI(model="gemini-pro", google_api_key=GOOGLE_API_KEY)
+    llm = ChatGoogleGenerativeAI(model="gemini-2.0-flash-exp", temperature=0, google_api_key=GOOGLE_API_KEY)
     structured_llm = llm.with_structured_output(RouteQuery)
     return prompt | structured_llm
 
@@ -48,6 +46,7 @@ def router_node(state: GraphState) -> str:
     result = query_router.invoke({"query": state["user_query"]})
     
     if result.destination:
+        print(f"-- Node enrutador: Decisión ir a {result.destination} --")
         return result.destination
     else:
         return "end"

--- a/plataforma-agricola-backend/app/agents/agent_router.py
+++ b/plataforma-agricola-backend/app/agents/agent_router.py
@@ -1,0 +1,53 @@
+from langchain_google_genai import ChatGoogleGenerativeAI
+from langchain_core.prompts import PromptTemplate
+from langchain_core.pydantic_v1 import BaseModel, Field
+
+from app.core.config import GOOGLE_API_KEY
+from app.agents.graph_state import GraphState
+
+llm = ChatGoogleGenerativeAI(model="gemini-2.0-flash-exp", temperature=0, google_api_key=GOOGLE_API_KEY)
+
+class RouteQuery(BaseModel):
+    """Enruta una consulta de usuario a un agente especialista."""
+    destination: str = Field(
+        description="El nombre del agente especialista al que se debe enrutar la consulta. Debe ser uno de: ['production', 'water', 'supply_chain', 'general']"
+    )
+
+def get_router():
+    """Crea y devuelve el enrutador de consultas."""
+    prompt = PromptTemplate(
+        template="""
+        Eres un director de proyecto experto en una empresa de tecnología agrícola.
+        Tu trabajo es analizar la siguiente pregunta de un agricultor y decidir qué departamento (agente especialista) es el más adecuado para responderla.
+
+        Aquí están los departamentos disponibles:
+        - 'production': Expertos en maximizar el rendimiento de los cultivos, sugerir prácticas de manejo, fertilizantes, etc.
+        - 'water': Expertos en riego, gestión y conservación del agua.
+        - 'supply_chain': Expertos en logística, inventario, transporte y venta de productos.
+        - 'general': Equipo de soporte general que puede responder preguntas sobre datos de parcelas o temas no cubiertos por los especialistas.
+
+        Pregunta del usuario:
+        "{query}"
+
+        ¿A qué departamento deberías enrutar esta pregunta?
+        """,
+        input_variables=["query"],
+    )
+
+    llm = ChatGoogleGenerativeAI(model="gemini-pro", google_api_key=GOOGLE_API_KEY)
+    structured_llm = llm.with_structured_output(RouteQuery)
+    return prompt | structured_llm
+
+query_router = get_router()
+
+def router_node(state: GraphState) -> str:
+    """
+    Nodo enrutador que decide el siguiente paso.
+    """
+
+    result = query_router.invoke({"query": state["user_query"]})
+    
+    if result.destination:
+        return result.destination
+    else:
+        return "end"

--- a/plataforma-agricola-backend/app/agents/graph_builder.py
+++ b/plataforma-agricola-backend/app/agents/graph_builder.py
@@ -1,4 +1,4 @@
-from langgraph.graph import StateGraph, END
+from langgraph.graph import StateGraph, END, START
 from app.agents.graph_state import GraphState
 from app.agents.agent_router import router_node
 from app.agents.agent_nodes import (
@@ -12,20 +12,16 @@ from app.agents.agent_nodes import (
 workflow = StateGraph(GraphState)
 
 # Añadir los nodos al grafo
-workflow.add_node("router", router_node)
 workflow.add_node("general_agent", general_tool_agent_node)
 workflow.add_node("production_agent", production_agent_node)
 workflow.add_node("water_agent", water_agent_node)
 workflow.add_node("supply_chain_agent", supply_chain_agent_node)
 # workflow.add_node("sustainability_agent", sustainability_agent_node)
 
-# Establecer el punto de entrada
-workflow.set_entry_point("router")
-
 # Aristas condicionales
 workflow.add_conditional_edges(
-    "router",
-    lambda state: router_node(state),
+    START,
+    router_node,
     {
         "production": "production_agent",
         "water": "water_agent",

--- a/plataforma-agricola-backend/app/agents/graph_builder.py
+++ b/plataforma-agricola-backend/app/agents/graph_builder.py
@@ -1,16 +1,45 @@
 from langgraph.graph import StateGraph, END
 from app.agents.graph_state import GraphState
-from app.agents.agent_nodes import monitoring_agent_node, sustainability_agent_node
+from app.agents.agent_router import router_node
+from app.agents.agent_nodes import (
+    general_tool_agent_node,
+    production_agent_node,
+    water_agent_node,
+    supply_chain_agent_node,
+    sustainability_agent_node,
+)
 
 workflow = StateGraph(GraphState)
 
-workflow.add_node("monitoring_agent", monitoring_agent_node)
-workflow.add_node("sustainability_agent", sustainability_agent_node)
+# Añadir los nodos al grafo
+workflow.add_node("router", router_node)
+workflow.add_node("general_agent", general_tool_agent_node)
+workflow.add_node("production_agent", production_agent_node)
+workflow.add_node("water_agent", water_agent_node)
+workflow.add_node("supply_chain_agent", supply_chain_agent_node)
+# workflow.add_node("sustainability_agent", sustainability_agent_node)
 
-workflow.set_entry_point("monitoring_agent")
+# Establecer el punto de entrada
+workflow.set_entry_point("router")
 
-workflow.add_edge("monitoring_agent", "sustainability_agent")
+# Aristas condicionales
+workflow.add_conditional_edges(
+    "router",
+    lambda state: router_node(state),
+    {
+        "production": "production_agent",
+        "water": "water_agent",
+        "supply_chain": "supply_chain_agent",
+        "general": "general_agent",
+        "end": END
+    }
+)
 
-workflow.add_edge("sustainability_agent", END)
+# Nodos especializados para terminar el flujo de trabajo
+workflow.add_edge("general_agent", END)
+workflow.add_edge("production_agent", END)
+workflow.add_edge("water_agent", END)
+workflow.add_edge("supply_chain_agent", END)
 
+# Se compila el grafo
 agent_graph = workflow.compile()


### PR DESCRIPTION
### Resumen
Se agrego una función de nodo para cada agente especializado, inicialmente sin herramientas complejas. Creación de un nodo enrutador, el cual decidirá que agente especializado debe responder o enviarse. Finalmente, se reconstruye el grafo con el enrutamiento condicional.

### Cambios
- Se renombro un agente nodo, el de monitoreo a agente general
- Nodos agregador en los nodos de agente
- Se agrego el enrutamiento condicional en el graph builder
- Mayor visibilidad para saber que decisión se toma en el router y que agente esta actuando, en los agent node y agent router

### Tests
1. Se ingresa al endpoint /docs
2. Una vez Autorizados se va al endpoint /chat
3. Se hace preguntas y se observa que agente actúa

### Checklist
- [x] Crear Nodos de Agente Especializados
- [x] Crear un Nodo Enrutador (Router Node)
- [x] Reconstruir el Grafo con Enrutamiento Condicional