### PR TITLE
feat(backend): agregar rag y api tool al agente supply chain

### DIFF
--- a/plataforma-agricola-backend/app/agents/agent_tools.py
+++ b/plataforma-agricola-backend/app/agents/agent_tools.py
@@ -90,3 +90,22 @@ def get_weather_forecast(location:str)->str:
         return f"Error HTTP al obtener el pronóstico: {http_err}"
     except Exception as e:
         return f"Ocurrió un error inesperado al obtener el pronóstico: {e}"
+    
+@tool
+def get_market_price(product_name: str) -> str:
+    """
+    Útil para obtener el precio de mercado actual y la tendencia para un producto agrícola específico.
+    El producto debe ser un nombre simple como 'tomate', 'maíz', etc.
+    """
+    print(f"---USANDO HERRAMIENTA: get_market_price para {product_name}---")
+    try:
+        response = requests.get(f"http://127.0.0.1:8000/mock/market-prices?product_name={product_name}")
+        response.raise_for_status()
+        data = response.json()
+        return f"El precio de mercado para '{product_name}' es de ${data['price_usd_kg']} USD por kg, con una tendencia '{data['trend']}'."
+    except requests.exceptions.HTTPError as http_err:
+        if http_err.response.status_code == 404:
+            return f"No se encontraron datos de precios para '{product_name}'."
+        return f"Error al obtener los precios: {http_err}"
+    except Exception as e:
+        return f"Ocurrió un error inesperado: {e}"

--- a/plataforma-agricola-backend/app/api/mock_data.py
+++ b/plataforma-agricola-backend/app/api/mock_data.py
@@ -1,0 +1,21 @@
+from fastapi import APIRouter, HTTPException
+
+router = APIRouter()
+
+# Base de datos simulada de precios
+MOCK_PRICES = {
+    "tomate": {"price_usd_kg": 1.5, "trend": "estable"},
+    "maíz": {"price_usd_kg": 0.3, "trend": "al alza"},
+    "papa": {"price_usd_kg": 0.8, "trend": "a la baja"},
+}
+
+@router.get("/market-prices")
+def get_market_prices(product_name: str):
+    """
+    Endpoint simulado que devuelve los precios de mercado para un producto.
+    """
+    product_key = product_name.lower()
+    if product_key not in MOCK_PRICES:
+        raise HTTPException(status_code=404, detail=f"No se encontraron precios para el producto: {product_name}")
+    
+    return MOCK_PRICES[product_key]

--- a/plataforma-agricola-backend/app/main.py
+++ b/plataforma-agricola-backend/app/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app.api import users, parcels, chat, auth 
+from app.api import users, parcels, chat, auth, mock_data
 
 app = FastAPI(
     title="Plataforma Multiagrente para Agricultura Sostenible",
@@ -21,6 +21,7 @@ app.include_router(router=users.router, prefix="/users", tags=["Users"])
 app.include_router(router=parcels.router, prefix="/parcels", tags=["Parcels"])
 app.include_router(router=chat.router, prefix="/chat", tags=["Chat"])
 app.include_router(router=auth.router, tags=["Authentication"])
+app.include_router(mock_data.router, prefix="/mock", tags=["Mock Data"])
 
 @app.get("/")
 def read_root():

--- a/plataforma-agricola-frontend/app.json
+++ b/plataforma-agricola-frontend/app.json
@@ -39,6 +39,12 @@
           }
         }
       ],
+      [
+        "expo-image-picker",
+        {
+          "photosPermission": "The app accesses your photos to let you share them with your friends."
+        }
+      ],
       "expo-secure-store"
     ],
     "experiments": {

--- a/plataforma-agricola-frontend/app/(auth)/signup/index.tsx
+++ b/plataforma-agricola-frontend/app/(auth)/signup/index.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { useAuth } from '@/context/AuthContext';
 import { Alert, View, Text, TextInput, Button, StyleSheet } from 'react-native';
 import { useRouter } from 'expo-router';
-import { registerUser } from '@/services/auth'; // Importa la función de registro
+import { registerUser } from '@/services/auth';
 
 export default function Register() {
     const router = useRouter();

--- a/plataforma-agricola-frontend/app/_layout.tsx
+++ b/plataforma-agricola-frontend/app/_layout.tsx
@@ -19,7 +19,7 @@ function InitialLoadingScreen() {
 
 export default function RootLayout() {
   return (
-    <SafeAreaProvider>
+    <SafeAreaProvider style={styles.container}>
       <SafeAreaView style={styles.container}>
         <AuthProvider>
           <InitialLoadingScreen />

--- a/plataforma-agricola-frontend/package-lock.json
+++ b/plataforma-agricola-frontend/package-lock.json
@@ -18,6 +18,7 @@
         "expo-font": "~14.0.8",
         "expo-haptics": "~15.0.7",
         "expo-image": "~3.0.8",
+        "expo-image-picker": "~17.0.8",
         "expo-linking": "~8.0.8",
         "expo-router": "~6.0.7",
         "expo-secure-store": "~15.0.7",
@@ -6742,6 +6743,27 @@
         "react-native-web": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-image-loader": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-6.0.0.tgz",
+      "integrity": "sha512-nKs/xnOGw6ACb4g26xceBD57FKLFkSwEUTDXEDF3Gtcu3MqF3ZIYd3YM+sSb1/z9AKV1dYT7rMSGVNgsveXLIQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-17.0.8.tgz",
+      "integrity": "sha512-489ByhVs2XPoAu9zodivAKLv7hG4S/FOe8hO/C2U6jVxmRjpAKakKNjMml0IwWjf1+c/RYBqm1XxKaZ+vq/fDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~6.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-keep-awake": {

--- a/plataforma-agricola-frontend/package.json
+++ b/plataforma-agricola-frontend/package.json
@@ -21,6 +21,7 @@
     "expo-font": "~14.0.8",
     "expo-haptics": "~15.0.7",
     "expo-image": "~3.0.8",
+    "expo-image-picker": "~17.0.8",
     "expo-linking": "~8.0.8",
     "expo-router": "~6.0.7",
     "expo-secure-store": "~15.0.7",

--- a/plataforma-agricola-frontend/services/chat.ts
+++ b/plataforma-agricola-frontend/services/chat.ts
@@ -2,11 +2,13 @@ import apiClient from "./api";
 import { ChatRequest, ChatResponse } from "@/types/chat";
 
 export const sendChatMessage = async (
-  message: string
+  message: string,
+  imageUri: string | null 
 ): Promise<ChatResponse> => {
   try {
     const response = await apiClient.post<ChatResponse>("/chat/", {
       message: message,
+      image_base64: imageUri
     });
     return response.data;
   } catch (error) {

--- a/plataforma-agricola-frontend/types/chat.ts
+++ b/plataforma-agricola-frontend/types/chat.ts
@@ -5,3 +5,10 @@ export interface ChatRequest {
 export interface ChatResponse {
   reply: string;
 }
+
+export interface Message {
+  id: string;
+  sender: 'user' | 'ai';
+  text?: string;
+  imageUrl?: string | null;
+}


### PR DESCRIPTION
### Resumen
Agregamos documentos sobre estándares de calidad para que pueda responder preguntas específicas sobre la venta de productos y creamos una herramienta para consultar precios de mercado simulados.

### Cambios
- Modificamos el agente supply chain, para agregar la herramienta
-  Agregamos documentos sobre estándares de calidad del tomate

### Test
1. Ir al endopoint /docs
2. Autentícate y ve al chat.
3. Pregunta para la prueba del rag: "¿Qué firmeza debe tener un tomate para ser de Categoría I?"
4. Observa la terminal: se debería ver al router elegir al supply_chain_agent, y a este usar la herramienta knowledge_base_search. La respuesta debería basarse en el PDF.
5. Para la prueba de datos en tiempo real (API Tool): "¿A cómo está el precio del tomate hoy?"
6. Observa la terminal: Verifica ver al supply_chain_agent usar la herramienta get_market_price. La respuesta debería ser: "El precio de mercado para 'tomate' es de $1.5 USD por kg, con una tendencia 'estable'."

### Checklist
- [x] Añadir un nuevo documento a la biblioteca
- [x] Re-indexar la base de conocimiento
- [x] Potenciar con datos en tiempo real (API Tool)
- [x] Crear la herramienta para llamar a la API simulada
- [x] Equipar al agente de cadena de suministro
- [x] Prueba del especialista